### PR TITLE
fix: update provider version required to fix the error of inconsistent rg data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For more information on access and permissions, see <https://cloud.ibm.com/docs/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.76.1, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.1, < 2.0.0 |
 
 ### Modules
 

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.76.1, < 2.0.0"
+      version = ">= 1.79.1, < 2.0.0"
     }
   }
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.76.1"
+      version = "1.79.1"
     }
   }
 }

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.78.3"
+      version = "1.79.1"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.76.1, < 2.0.0"
+      version = ">= 1.79.1, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description
Update to fix bug in provider giving inconsistent data on resource group creation/lookup, fixed in 1.79

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
